### PR TITLE
Fix CHANGELOG

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,21 +23,21 @@ Fixed
 Security
 ========
 
-[1.3.1] - 2019-08-30
+[1.3.2] - 2019-12-20
 ********************
 
 Changed
 =======
 - Changed log level of error messages from debug to error
 
-[1.3] - 2019-04-26
+[1.3.1] - 2019-04-26
 ******************
 
 Fixed
 =======
 - Fixed broken API error on flow module.
 
-[1.2.1] - 2019-03-15
+[1.3] - 2019-03-15
 ********************
 Added
 =====

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_core",
   "description": "OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "napp_dependencies": [],
   "license": "MIT",
   "url": "https://github.com/kytos/of_core.git",


### PR DESCRIPTION
In c97c1b07, version was bumped to 1.3 but change log was created as 1.2.1.
This commit fixes that and adds the new 1.3.2 release.