### PR TITLE
Set a new default value for the flow priority.

### DIFF
--- a/flow.py
+++ b/flow.py
@@ -50,7 +50,7 @@ class FlowBase(ABC):  # pylint: disable=too-many-instance-attributes
     _flow_mod_class = None
     _match_class = None
 
-    def __init__(self, switch, table_id=0xff, match=None, priority=0,
+    def __init__(self, switch, table_id=0xff, match=None, priority=0x8000,
                  idle_timeout=0, hard_timeout=0, cookie=0, actions=None,
                  stats=None):
         """Assign parameters to attributes.


### PR DESCRIPTION
Flow priority was with the default value of 0, that is the smallest possible value.
Now it is set to `0x8000` (2<sup>15</sup>), a value in the middle of `range(0, 2**16)`.
Fixes #51. 