### PR TITLE
Problem running coverage in Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,7 +6,7 @@ filter:
     paths: ['*']
 build:
     environment:
-        python: 3.6.0
+        python: 3.6.2
         postgresql: false
         redis: false
     tests:

--- a/main.py
+++ b/main.py
@@ -206,7 +206,7 @@ class Main(KytosNApp):
                 log.error(err)
                 if isinstance(err, AttributeError):
                     error_msg = 'connection closed before version negotiation'
-                    log.error('Connection %s: %s', connection.id, debug_msg)
+                    log.error('Connection %s: %s', connection.id, error_msg)
                 connection.close()
                 return
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@
 -e .
 astroid==2.0.4            # via pylint
 click==6.7                # via pip-tools
-coverage==4.5.1
+coverage==5.0.3
 docopt==0.6.2             # via yala
 isort==4.3.4              # via pylint, yala
 lazy-object-proxy==1.3.1  # via astroid


### PR DESCRIPTION
When running scrutinizer a conflict in .coverage version breaks the checks. The requirements specify coverage 4.5.1, that generate .coverage in 4.x version format. After this scrutinizer are running "pip install coverage" that apparently installing  coverage 5.0.3. Lastly, Scrutinizer breaks trying  to read .coverage (in 4.x version format) using coverage 5.0.3. 