### PR TITLE
Create tags decorator to tests

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -20,6 +20,7 @@ py==1.6.0                 # via tox
 pycodestyle==2.4.0        # via yala
 pydocstyle==2.1.1         # via yala
 pylint==2.1.1             # via yala
+pytest==5.4.1             # via pytest
 six==1.11.0               # via astroid, pip-tools, pydocstyle, tox
 snowballstemmer==1.2.1    # via pydocstyle
 toml==0.9.6               # via tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[aliases]
+test_fw=pytest
+
 [pycodestyle]
 exclude = .eggs,ENV,build,docs/conf.py,venv
 
@@ -15,3 +18,9 @@ known_first_party = kytos.core,tests
 known_third_party = pyof
 # Ignoring tests because is adding napps path
 skip=tests
+
+[tool:pytest]
+markers =
+    small: marks tests as small
+    medium: marks tests as medium
+    large: marks tests as large


### PR DESCRIPTION
Today, all the tests are executed without distinction. This commit creates a tag to divide tests in type (unit, integration, e2e) and in size (small, medium, large, all). "Unit" and "all" are the standard parameters.

To set tags to a test function:

```python
import pytest

@pytest.mark.medium
def test_function():
...
```
To run the tests:

```shell
 python setup.py ci --size=all --type=unit
```

The _'test'_ parameter uses the standard arguments and each function starts with small size argument by default.

By default, Pytest only runs tests inside folder defined in type argument (It isn't necessary to use the type argument in the tag decorator).

Directory hierarchy:

```
/tests/
... e2e/
... integration/
... unit/
```

Related 
https://github.com/kytos/kytos/issues/1041