### PR TITLE
Avoid inaccurate code coverage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,8 @@ class TestCoverage(SimpleCommand):
     def run(self):
         """Run unittest quietly and display coverage report."""
         # temporarily disabling running integration tests
-        cmd = 'coverage3 run -m unittest discover -s tests/unit\
-        && coverage3 report'
+        cmd = ('coverage3 run -m unittest discover -s tests/unit'
+               ' && coverage3 report')
         call(cmd, shell=True)
 
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,9 @@ class TestCoverage(SimpleCommand):
 
     def run(self):
         """Run unittest quietly and display coverage report."""
-        cmd = 'coverage3 run -m unittest && coverage3 report'
+        # temporarily disabling running integration tests
+        cmd = 'coverage3 run -m unittest discover -s tests/unit\
+        && coverage3 report'
         call(cmd, shell=True)
 
 


### PR DESCRIPTION
Today, running integration tests and unit tests together, code coverage is merged,
generating inaccurate value for coverage. This commit solves this problem
temporarily disabling the execution of integration tests.