### PR TITLE
Update .coveragerc to ignore .eggs in tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 source = .
-omit = *tests*,.tox/*,setup.py
+omit = .eggs/*,.tox/*,*tests*,setup.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[aliases]
-test_fw=pytest
-
 [pycodestyle]
 exclude = .eggs,ENV,build,docs/conf.py,venv
 

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ class Test(TestCommand):
 
     def run(self):
         """Run tests."""
-        cmd = 'python setup.py test_fw %s' % self.get_args()
+        cmd = 'python setup.py pytest %s' % self.get_args()
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
@@ -125,7 +125,7 @@ class TestCoverage(Test):
 
     def run(self):
         """Run tests quietly and display coverage report."""
-        cmd = 'coverage3 run setup.py test_fw %s' % self.get_args()
+        cmd = 'coverage3 run setup.py pytest %s' % self.get_args()
         cmd += '&& coverage3 report'
         try:
             check_call(cmd, shell=True)

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,1 +1,1 @@
-"""Unit Tests."""
+"""kytos/of_core unit tests."""


### PR DESCRIPTION
Today, when tests are running, files inside .eggs dir are include to be tested. This commit changes .coveragerc to ignore them and removes test_fw alias.