### PR TITLE
Fix handle_port_desc method

### DIFF
--- a/v0x04/utils.py
+++ b/v0x04/utils.py
@@ -85,13 +85,15 @@ def handle_port_desc(controller, switch, port_list):
             interface.address = port.hw_addr.value
             interface.state = port.state.value
             interface.features = port.curr
+            interface.set_custom_speed(port.curr_speed.value)
         else:
             interface = Interface(name=port.name.value,
                                   address=port.hw_addr.value,
                                   port_number=port.port_no.value,
                                   switch=switch,
                                   state=port.state.value,
-                                  features=port.curr)
+                                  features=port.curr,
+                                  speed=port.curr_speed.value)
         switch.update_interface(interface)
         port_event = KytosEvent(name='kytos/of_core.switch.port.created',
                                 content={


### PR DESCRIPTION
Today, handle_port_desc method isn't using speed to create Interface instances, so, an error is raised when this attribute is used. This PR changes this method, setting speed in all the Interface instances.

Fix kytos/kytos#1068