### PR TITLE
Periodically request for port statistics

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -252,12 +252,12 @@ class TestMain(TestCase):
         mock_connection.protocol.unpack.side_effect = AttributeError()
         self.napp.handle_raw_in(mock_event)
         self.assertEqual(mock_connection.close.call_count, 1)
-        
+
     @patch('napps.kytos.of_core.main.Main._new_port_stats')
     @patch('napps.kytos.of_core.main.Main._is_multipart_reply_ours')
     def test_handle_multipart_port_stats(self, *args):
         """Test handle multipart flow stats."""
-        (mock_is_multipart_reply_ours, 
+        (mock_is_multipart_reply_ours,
          mock_new_port_stats) = args
         mock_is_multipart_reply_ours.return_value = True
 
@@ -266,7 +266,8 @@ class TestMain(TestCase):
         port_stats_msg.flags.value = 2
         port_stats_msg.multipart_type = MultipartType.OFPMP_PORT_STATS
 
-        self.napp._handle_multipart_port_stats(port_stats_msg, self.switch_v0x04)
+        self.napp._handle_multipart_port_stats(port_stats_msg,
+                                               self.switch_v0x04)
 
         mock_is_multipart_reply_ours.assert_called_with(port_stats_msg,
                                                         self.switch_v0x04,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -187,7 +187,8 @@ class TestMain(TestCase):
         self.napp._handle_multipart_flow_stats(flow_msg, self.switch_v0x04)
 
         mock_is_multipart_reply_ours.assert_called_with(flow_msg,
-                                                        self.switch_v0x04)
+                                                        self.switch_v0x04,
+                                                        'flows')
         mock_from_of_flow_stats_v0x01.assert_called_with(flow_msg.body,
                                                          self.switch_v0x04)
         mock_update_switch_flows.assert_called_with(self.switch_v0x04)
@@ -198,9 +199,9 @@ class TestMain(TestCase):
         mock_switch = get_switch_mock(dpid)
         mock_switch.id = dpid
         self.napp._multipart_replies_flows = {dpid: mock_switch}
-        self.napp._multipart_replies_xids = {dpid: mock_switch}
+        self.napp._multipart_replies_xids = {dpid: {'flows': mock_switch}}
         self.napp._update_switch_flows(mock_switch)
-        self.assertEqual(self.napp._multipart_replies_xids, {})
+        self.assertEqual(self.napp._multipart_replies_xids, {dpid: {}})
         self.assertEqual(self.napp._multipart_replies_flows, {})
 
     def test_is_multipart_reply_ours(self):
@@ -212,11 +213,13 @@ class TestMain(TestCase):
         mock_reply.header.xid = mock_switch
         type(mock_switch).id = PropertyMock(side_effect=[dpid_a,
                                                          dpid_a, dpid_b])
-        self.napp._multipart_replies_xids = {dpid_a: mock_switch}
-        response = self.napp._is_multipart_reply_ours(mock_reply, mock_switch)
+        self.napp._multipart_replies_xids = {dpid_a: {'flows': mock_switch}}
+        response = self.napp._is_multipart_reply_ours(
+            mock_reply, mock_switch, 'flows')
         self.assertEqual(response, True)
 
-        response = self.napp._is_multipart_reply_ours(mock_reply, mock_switch)
+        response = self.napp._is_multipart_reply_ours(
+            mock_reply, mock_switch, 'flows')
         self.assertEqual(response, False)
 
     @patch('napps.kytos.of_core.main.of_slicer')
@@ -249,6 +252,26 @@ class TestMain(TestCase):
         mock_connection.protocol.unpack.side_effect = AttributeError()
         self.napp.handle_raw_in(mock_event)
         self.assertEqual(mock_connection.close.call_count, 1)
+        
+    @patch('napps.kytos.of_core.main.Main._new_port_stats')
+    @patch('napps.kytos.of_core.main.Main._is_multipart_reply_ours')
+    def test_handle_multipart_port_stats(self, *args):
+        """Test handle multipart flow stats."""
+        (mock_is_multipart_reply_ours, 
+         mock_new_port_stats) = args
+        mock_is_multipart_reply_ours.return_value = True
+
+        port_stats_msg = MagicMock()
+        port_stats_msg.body = "A"
+        port_stats_msg.flags.value = 2
+        port_stats_msg.multipart_type = MultipartType.OFPMP_PORT_STATS
+
+        self.napp._handle_multipart_port_stats(port_stats_msg, self.switch_v0x04)
+
+        mock_is_multipart_reply_ours.assert_called_with(port_stats_msg,
+                                                        self.switch_v0x04,
+                                                        'ports')
+        mock_new_port_stats.assert_called_with(self.switch_v0x04)
 
     @patch('napps.kytos.of_core.main.Main.update_port_status')
     @patch('napps.kytos.of_core.main.Main.update_links')

--- a/v0x01/utils.py
+++ b/v0x01/utils.py
@@ -1,5 +1,6 @@
 """Utilities module for of_core OpenFlow v0x01 operations."""
-from pyof.v0x01.controller2switch.common import ConfigFlag, FlowStatsRequest, PortStatsRequest
+from pyof.v0x01.controller2switch.common import (ConfigFlag, FlowStatsRequest,
+                                                 PortStatsRequest)
 from pyof.v0x01.controller2switch.set_config import SetConfig
 from pyof.v0x01.controller2switch.stats_request import StatsRequest, StatsType
 from pyof.v0x01.symmetric.echo_request import EchoRequest
@@ -26,8 +27,10 @@ def update_flow_list(controller, switch):
     # req.pack()
     emit_message_out(controller, switch.connection, stats_request)
 
+
 def request_port_stats(controller, switch):
     """Request port stats from switches.
+
     Args:
         controller(:class:`~kytos.core.controller.Controller`):
             the controller being used.
@@ -40,6 +43,7 @@ def request_port_stats(controller, switch):
         body=body)
     # req.pack()
     emit_message_out(controller, switch.connection, stats_request)
+
 
 def send_desc_request(controller, switch):
     """Send a description request to the switch.

--- a/v0x01/utils.py
+++ b/v0x01/utils.py
@@ -1,5 +1,5 @@
 """Utilities module for of_core OpenFlow v0x01 operations."""
-from pyof.v0x01.controller2switch.common import ConfigFlag, FlowStatsRequest
+from pyof.v0x01.controller2switch.common import ConfigFlag, FlowStatsRequest, PortStatsRequest
 from pyof.v0x01.controller2switch.set_config import SetConfig
 from pyof.v0x01.controller2switch.stats_request import StatsRequest, StatsType
 from pyof.v0x01.symmetric.echo_request import EchoRequest
@@ -26,6 +26,20 @@ def update_flow_list(controller, switch):
     # req.pack()
     emit_message_out(controller, switch.connection, stats_request)
 
+def request_port_stats(controller, switch):
+    """Request port stats from switches.
+    Args:
+        controller(:class:`~kytos.core.controller.Controller`):
+            the controller being used.
+        switch(:class:`~kytos.core.switch.Switch`):
+            target to send a stats request.
+    """
+    body = PortStatsRequest()
+    stats_request = StatsRequest(
+        body_type=StatsType.OFPST_PORT,
+        body=body)
+    # req.pack()
+    emit_message_out(controller, switch.connection, stats_request)
 
 def send_desc_request(controller, switch):
     """Send a description request to the switch.

--- a/v0x04/utils.py
+++ b/v0x04/utils.py
@@ -2,6 +2,7 @@
 from pyof.v0x04.common.action import ControllerMaxLen
 from pyof.v0x04.controller2switch.common import ConfigFlag, MultipartType
 from pyof.v0x04.controller2switch.multipart_request import (FlowStatsRequest,
+                                                            PortStatsRequest,
                                                             MultipartRequest)
 from pyof.v0x04.controller2switch.set_config import SetConfig
 from pyof.v0x04.symmetric.echo_request import EchoRequest
@@ -31,6 +32,24 @@ def update_flow_list(controller, switch):
     emit_message_out(controller, switch.connection, multipart_request)
     return multipart_request.header.xid
 
+def request_port_stats(controller, switch):
+    """Request port stats from switches.
+
+    Args:
+        controller(:class:`~kytos.core.controller.Controller`):
+            the controller being used.
+        switch(:class:`~kytos.core.switch.Switch`):
+            target to send a stats request.
+
+    Returns:
+        int: multipart request xid
+
+    """
+    multipart_request = MultipartRequest()
+    multipart_request.multipart_type = MultipartType.OFPMP_PORT_STATS
+    multipart_request.body = PortStatsRequest()
+    emit_message_out(controller, switch.connection, multipart_request)
+    return multipart_request.header.xid
 
 def send_desc_request(controller, switch):
     """Request vendor-specific switch description.

--- a/v0x04/utils.py
+++ b/v0x04/utils.py
@@ -2,8 +2,8 @@
 from pyof.v0x04.common.action import ControllerMaxLen
 from pyof.v0x04.controller2switch.common import ConfigFlag, MultipartType
 from pyof.v0x04.controller2switch.multipart_request import (FlowStatsRequest,
-                                                            PortStatsRequest,
-                                                            MultipartRequest)
+                                                            MultipartRequest,
+                                                            PortStatsRequest)
 from pyof.v0x04.controller2switch.set_config import SetConfig
 from pyof.v0x04.symmetric.echo_request import EchoRequest
 from pyof.v0x04.symmetric.hello import Hello
@@ -32,6 +32,7 @@ def update_flow_list(controller, switch):
     emit_message_out(controller, switch.connection, multipart_request)
     return multipart_request.header.xid
 
+
 def request_port_stats(controller, switch):
     """Request port stats from switches.
 
@@ -50,6 +51,7 @@ def request_port_stats(controller, switch):
     multipart_request.body = PortStatsRequest()
     emit_message_out(controller, switch.connection, multipart_request)
     return multipart_request.header.xid
+
 
 def send_desc_request(controller, switch):
     """Request vendor-specific switch description.


### PR DESCRIPTION
Request port statistics when requesting for flow statistics.
When the reply is received, an event is created with the list of port stats received.

For OpenFlow 1.3, there was a dictionary of xid's, to keep track of the multipart replies.
The dictionary contents were like `{dpid: xid}`. Now, it is necessary to keep track of
two xid's for each switch, so the dicitonary contents are: `{dpid: {'flows': xid1, 'ports': xid2}}`