### PR TITLE
Change setup.py to alert when Travis fails

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,8 @@ class Test(TestCommand):
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
             print(exc)
+            print('Unit tests failed. Fix the errors above and try again.')
+            sys.exit(-1)
 
 
 class TestCoverage(Test):
@@ -131,6 +133,8 @@ class TestCoverage(Test):
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
             print(exc)
+            print('Coverage tests failed. Fix the errors above and try again.')
+            sys.exit(-1)
 
 
 class Linter(SimpleCommand):


### PR DESCRIPTION
Today, when tests fail on Travis, it does not raise errors. This PR changes setup.py to fix this problem.