### PR TITLE
Disable useless debug message about Raw OpenFlow packet

### DIFF
--- a/main.py
+++ b/main.py
@@ -217,8 +217,6 @@ class Main(KytosNApp):
         for packet in packets:
             if not connection.is_alive():
                 return
-            log.debug('Connection %s: New Raw Openflow packet - %s',
-                      connection.id, packet.hex())
 
             if connection.is_new():
                 try:


### PR DESCRIPTION
Hello team,

This pull request is related to the issue #103 (https://github.com/kytos/of_core/issues/103)

To fix the issue, my patch just remove some unnecessary logging call on of_core/main.py

By accepting this patch, kytos/of_core will have a significant improvement on the logging management for debug mode and the troubleshooting process will be made easier.