### PR TITLE
Add dpid and xid to OFPT_ERROR log message

### DIFF
--- a/main.py
+++ b/main.py
@@ -239,7 +239,9 @@ class Main(KytosNApp):
             try:
                 message = connection.protocol.unpack(packet)
                 if message.header.message_type == Type.OFPT_ERROR:
-                    log.error(f"OFPT_ERROR: {str(message.code)}")
+                    log.error(f"OFPT_ERROR: {str(message.code)} error code "
+                              "received from switch {switch.dpid} with xid "
+                              "{message.header.xid}")
             except (UnpackException, AttributeError) as err:
                 log.error(err)
                 if isinstance(err, AttributeError):


### PR DESCRIPTION
### :octocat: Fix issue #99

### :bookmark_tabs: Description of the Change

This PR adds the dpid of switch and the xid to log error message OFPT_ERROR.

### :page_facing_up: Release Notes

"N/A" here.