### PR TITLE
Update the default value `table_id` in the `FlowBase` class

### DIFF
--- a/flow.py
+++ b/flow.py
@@ -50,7 +50,7 @@ class FlowBase(ABC):  # pylint: disable=too-many-instance-attributes
     _flow_mod_class = None
     _match_class = None
 
-    def __init__(self, switch, table_id=0xff, match=None, priority=0x8000,
+    def __init__(self, switch, table_id=0x0, match=None, priority=0x8000,
                  idle_timeout=0, hard_timeout=0, cookie=0, actions=None,
                  stats=None):
         """Assign parameters to attributes.
@@ -58,7 +58,7 @@ class FlowBase(ABC):  # pylint: disable=too-many-instance-attributes
         Args:
             switch (kytos.core.switch.Switch): Switch ID is used to uniquely
                 identify a flow.
-            table_id (int): The index of a single table or 0xff for all tables.
+            table_id (int): The index of a single table.
             match (|match|): Match object.
             priority (int): Priority level of flow entry.
             idle_timeout (int): Idle time before discarding, in seconds.

--- a/flow.py
+++ b/flow.py
@@ -185,6 +185,7 @@ class FlowBase(ABC):  # pylint: disable=too-many-instance-attributes
         flow_mod.idle_timeout = self.idle_timeout
         flow_mod.hard_timeout = self.hard_timeout
         flow_mod.priority = self.priority
+        flow_mod.table_id = self.table_id
         return flow_mod
 
     @staticmethod

--- a/flow.py
+++ b/flow.py
@@ -58,7 +58,8 @@ class FlowBase(ABC):  # pylint: disable=too-many-instance-attributes
         Args:
             switch (kytos.core.switch.Switch): Switch ID is used to uniquely
                 identify a flow.
-            table_id (int): The index of a single table.
+            table_id (int): The index of a single table or 0xff for all tables
+                            (0xff is valid only for the delete command)
             match (|match|): Match object.
             priority (int): Priority level of flow entry.
             idle_timeout (int): Idle time before discarding, in seconds.


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

Proposal to fix: https://github.com/kytos/flow_manager/issues/108
Fix: https://github.com/kytos/flow_manager/issues/107


### :bookmark_tabs: Description of the Change

The default value of `table_id` `0xff` (255) in the `FlowBase` class are resulting in an error in the consistency mechanism. 

### :page_facing_up: Release Notes

- Change the default value of `table_id` in `FlowBase` class to `0x0` instead of `0xff`.
