### PR TITLE
Fix the string formatting in OFPT_ERROR log message

### DIFF
--- a/main.py
+++ b/main.py
@@ -239,9 +239,9 @@ class Main(KytosNApp):
             try:
                 message = connection.protocol.unpack(packet)
                 if message.header.message_type == Type.OFPT_ERROR:
-                    log.error(f"OFPT_ERROR: {str(message.code)} error code "
-                              "received from switch {switch.dpid} with xid "
-                              "{message.header.xid}")
+                    log.error("OFPT_ERROR: %s error code received from"
+                              " switch %s with xid %s", str(message.code),
+                              switch.dpid, message.header.xid)
             except (UnpackException, AttributeError) as err:
                 log.error(err)
                 if isinstance(err, AttributeError):

--- a/main.py
+++ b/main.py
@@ -240,7 +240,7 @@ class Main(KytosNApp):
                 message = connection.protocol.unpack(packet)
                 if message.header.message_type == Type.OFPT_ERROR:
                     log.error("OFPT_ERROR: %s error code received from"
-                              " switch %s with xid %s", str(message.code),
+                              " switch %s with xid %s", message.code,
                               switch.dpid, message.header.xid)
             except (UnpackException, AttributeError) as err:
                 log.error(err)


### PR DESCRIPTION


# Pull Request Template

### :octocat: Are you working on some issue? Identify the issue!

Fix #114 


### :bookmark_tabs: Description of the Change

Fix the string formatting in OFPT_ERROR log message.
Now `switch.dpid` and `message.header.xid` are shown in log message.

### :computer: Verification Process

- Checked manually and the unit test is still passing.

### :page_facing_up: Release Notes

- Fix the string formatting in OFPT_ERROR log message
