### PR TITLE
Create a new event to notify when new flow stats are available

### DIFF
--- a/main.py
+++ b/main.py
@@ -167,6 +167,10 @@ class Main(KytosNApp):
             all_flows.extend(flows)
             if reply.flags.value % 2 == 0:  # Last bit means more replies
                 self._update_switch_flows(switch)
+                event_raw = KytosEvent(
+                    name='kytos/of_core.flow_stats.received',
+                    content={'switch': switch})
+                self.controller.buffers.app.put(event_raw)
 
     def _handle_multipart_port_stats(self, reply, switch):
         """Emit an event about new port stats."""
@@ -184,10 +188,6 @@ class Main(KytosNApp):
         switch.flows = self._multipart_replies_flows[switch.id]
         del self._multipart_replies_flows[switch.id]
         del self._multipart_replies_xids[switch.id]['flows']
-        event_raw = KytosEvent(
-            name='kytos/of_core.flow_stats.received',
-            content={'switch': switch})
-        self.controller.buffers.app.put(event_raw)
 
     def _new_port_stats(self, switch):
         """Send an event with the new port stats and clean resources."""

--- a/main.py
+++ b/main.py
@@ -133,7 +133,8 @@ class Main(KytosNApp):
             event (KytosEvent): Event with the switch' handshake completed
         """
         switch = event.content['switch']
-        self._request_flow_list(switch)
+        if switch.is_enabled():
+            self._request_flow_list(switch)
 
     @listen_to('kytos/of_core.v0x04.messages.in.ofpt_multipart_reply')
     def handle_multipart_reply(self, event):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -64,6 +64,24 @@ class TestMain(TestCase):
         mock_update_flow_list_v0x04.assert_called_with(self.napp.controller,
                                                        self.switch_v0x04)
 
+    @patch('napps.kytos.of_core.v0x04.utils.update_flow_list')
+    @patch('napps.kytos.of_core.v0x01.utils.update_flow_list')
+    def test_on_handshake_completed_request_flow_list(self, *args):
+        """Test request flow list."""
+        (mock_update_flow_list_v0x01, mock_update_flow_list_v0x04) = args
+        mock_update_flow_list_v0x04.return_value = "ABC"
+        name = 'kytos/of_core.handshake.completed'
+        content = {"switch": self.switch_v0x01}
+        event = get_kytos_event_mock(name=name, content=content)
+        self.napp.on_handshake_completed_request_flow_list(event)
+        mock_update_flow_list_v0x01.assert_called_with(self.napp.controller,
+                                                       self.switch_v0x01)
+        content = {"switch": self.switch_v0x04}
+        event = get_kytos_event_mock(name=name, content=content)
+        self.napp.on_handshake_completed_request_flow_list(event)
+        mock_update_flow_list_v0x04.assert_called_with(self.napp.controller,
+                                                       self.switch_v0x04)
+
     @patch('napps.kytos.of_core.v0x01.flow.Flow.from_of_flow_stats')
     def test_handle_stats_reply(self, mock_from_of_flow_stats_v0x01):
         """Test handle stats reply."""


### PR DESCRIPTION
Currently, of_core updates the flow statistics periodically based on the `settings.STATS_INTERVAL`, and there is no way to notify other NApps that new statistics are available. This can cause an inconsistent view of the switch's flow table if any other NApp uses `switch.flows` after a while since last received stats.

An example of such inconsistency is the flow_manager consistency check routine, as discussed in https://github.com/kytos/flow_manager/issues/124

This PR creates a new event to notify other NApps when new flow statistics are available.

Fixes #122 