### PR TITLE
Add Custom JSON encoder for OF 1.0 flow representation

### DIFF
--- a/flow.py
+++ b/flow.py
@@ -165,6 +165,11 @@ class FlowBase(ABC):  # pylint: disable=too-many-instance-attributes
             string: Flow JSON string representation.
 
         """
+        version = self.switch.connection.protocol.version
+        if version == 0x01:
+            return json.dumps(self.as_dict(include_id),
+                              cls=v0x01.utils.JSONEncoderOF10,
+                              sort_keys=sort_keys)
         return json.dumps(self.as_dict(include_id), sort_keys=sort_keys)
 
     def as_of_add_flow_mod(self):

--- a/tests/unit/v0x01/test_utils.py
+++ b/tests/unit/v0x01/test_utils.py
@@ -1,5 +1,5 @@
 """Test v0x01.utils methods."""
-from unittest import TestCase
+from unittest import TestCase, mock
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from kytos.lib.helpers import get_connection_mock, get_switch_mock
@@ -61,3 +61,31 @@ class TestUtils(TestCase):
         """Test say_hello."""
         say_hello(self.mock_controller, self.mock_switch)
         mock_emit_message_out.assert_called()
+
+
+class TestJSONEncoderOF10(TestCase):
+    """Test custom JSON encoder for OF 1.0 ."""
+
+    def setUp(self):
+        """Execute steps before each tests.
+        Set the server_name_url from kytos/of_core
+        """
+        patch('kytos.core.helpers.run_on_thread', lambda x: x).start()
+        # pylint: disable=import-outside-toplevel
+        from napps.kytos.of_core.v0x01.utils import JSONEncoderOF10
+        self.addCleanup(patch.stopall)
+
+        self.encoder = JSONEncoderOF10()
+
+    @patch('napps.kytos.of_core.v0x01.utils.UBIntBase', new=mock.Mock)
+    def test_cast(self):
+        """Test custom JSON encoder for OF 1.0 flow representation."""
+        object_mock = MagicMock()
+        response = self.encoder.default(object_mock)
+        self.assertEqual(response, 1)
+
+    @patch('json.JSONEncoder.default')
+    def test_cast_not_equal_case(self, mock_json):
+        """Test the custom JSON encoder in case the object is not UBInt."""
+        self.encoder.default('1')
+        mock_json.assert_called()

--- a/v0x01/utils.py
+++ b/v0x01/utils.py
@@ -1,4 +1,7 @@
 """Utilities module for of_core OpenFlow v0x01 operations."""
+import json
+
+from pyof.foundation.base import UBIntBase
 from pyof.v0x01.controller2switch.common import (ConfigFlag, FlowStatsRequest,
                                                  PortStatsRequest)
 from pyof.v0x01.controller2switch.set_config import SetConfig
@@ -9,6 +12,19 @@ from pyof.v0x01.symmetric.hello import Hello
 from kytos.core import KytosEvent
 from kytos.core.interface import Interface
 from napps.kytos.of_core.utils import emit_message_out
+
+
+class JSONEncoderOF10(json.JSONEncoder):
+    """Custom JSON encoder for OF 1.0 flow representation.
+
+    Make casting from UBInt8, UBInt16, UBInt32, UBInt64 to int.
+    """
+
+    def default(self, obj):  # pylint: disable=E0202,W0221
+        """Make casting from UBInt8, UBInt16, UBInt32, UBInt64 to int."""
+        if isinstance(obj, UBIntBase):
+            return int(obj)
+        return json.JSONEncoder.default(self, obj)
 
 
 def update_flow_list(controller, switch):


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

Related https://github.com/kytos/flow_manager/issues/97
### :bookmark_tabs: Description of the Change

Add Custom JSON encoder for OF 1.0 flow representation

### :computer: Verification Process

- Tested manually and unit tests are still passing.

### :page_facing_up: Release Notes


- Add a custom JSON encoder for OF 1.0 flow representation, solving the JSON `UBInt` serialization error.
