### PR TITLE
Add ``switch.interface.created`` event to ``PORT_DESC`` handler

### DIFF
--- a/tests/unit/v0x04/test_utils.py
+++ b/tests/unit/v0x04/test_utils.py
@@ -50,14 +50,14 @@ class TestUtils(TestCase):
         handle_port_desc(self.mock_controller, self.mock_switch, [mock_port])
         self.assertEqual(self.mock_switch.update_interface.call_count, 1)
         mock_event_buffer.assert_called()
-        self.assertEqual(self.mock_controller.buffers.app.put.call_count, 1)
+        self.assertEqual(self.mock_controller.buffers.app.put.call_count, 2)
 
         self.mock_switch.update_interface.call_count = 0
         self.mock_controller.buffers.app.put.call_count = 0
         handle_port_desc(self.mock_controller, self.mock_switch, [mock_port])
         self.assertEqual(self.mock_switch.update_interface.call_count, 1)
         mock_event_buffer.assert_called()
-        self.assertEqual(self.mock_controller.buffers.app.put.call_count, 1)
+        self.assertEqual(self.mock_controller.buffers.app.put.call_count, 2)
 
     @patch('napps.kytos.of_core.v0x04.utils.emit_message_out')
     def test_send_echo(self, mock_emit_message_out):

--- a/v0x04/utils.py
+++ b/v0x04/utils.py
@@ -125,8 +125,8 @@ def handle_port_desc(controller, switch, port_list):
                                   speed=port.curr_speed.value,
                                   config=config)
         switch.update_interface(interface)
-        interface_event = KytosEvent(name='kytos/of_core.switch'
-                                     '.interface.created',
+        event_name = 'kytos/of_core.switch.interface.created'
+        interface_event = KytosEvent(name=event_name,
                                      content={'interface': interface})
         port_event = KytosEvent(name='kytos/of_core.switch.port.created',
                                 content={

--- a/v0x04/utils.py
+++ b/v0x04/utils.py
@@ -125,6 +125,9 @@ def handle_port_desc(controller, switch, port_list):
                                   speed=port.curr_speed.value,
                                   config=config)
         switch.update_interface(interface)
+        interface_event = KytosEvent(name='kytos/of_core.switch'
+                                     '.interface.created',
+                                     content={'interface': interface})
         port_event = KytosEvent(name='kytos/of_core.switch.port.created',
                                 content={
                                     'switch': switch.id,
@@ -136,6 +139,7 @@ def handle_port_desc(controller, switch, port_list):
                                         }
                                     })
         controller.buffers.app.put(port_event)
+        controller.buffers.app.put(interface_event)
 
 
 def send_echo(controller, switch):


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

Fix  https://github.com/kytos/topology/issues/158
Related: https://github.com/kytos/of_core/issues/116
Related to suggestion : https://github.com/kytos/of_core/issues/116#issuecomment-824313373

### :bookmark_tabs: Description of the Change

Add new event (``switch.interface.created``) to `handle_port_desc` method. 
This modification is an alternative to the pull request (https://github.com/kytos/topology/pull/160).

Now ``PORT_DESC`` method generate the events ``kytos/of_core.switch.interface.created`` and ``switch.port.created``. 
Before this commit, only `port.created` was generated in `PORT_DESC`.


### :computer: Verification Process

- N/A

### :page_facing_up: Release Notes

-


